### PR TITLE
Add JMTS_TELEMETRY and JMTS_TEST_OUTPUT_TO_STDERR env vars

### DIFF
--- a/lib/JMAP/TestSuite/Tester.pm
+++ b/lib/JMAP/TestSuite/Tester.pm
@@ -1,11 +1,20 @@
 use strict;
 use warnings;
 package JMAP::TestSuite::Tester;
+
 use Test::Routine 0.025;
+use Test::More;
+
+if ($ENV{JMTS_TELEMETRY}) {
+  $ENV{JMAP_TESTER_LOGGER} = 'HTTP:-2'; # STDERR
+}
+
+if ($ENV{JMTS_TEST_OUTPUT_TO_STDERR}) {
+  Test::More->builder->output(*STDERR);
+}
 
 use JMAP::TestSuite;
 use JMAP::TestSuite::Util;
-use Test::More;
 use Test::Deep ':v1';
 use Test::Deep::JType;
 


### PR DESCRIPTION
 * JMTS_TELEMETRY=1 turns on JMAP::Tester::Logger logging to
   STDERR.

 * JMTS_TEST_OUTPUT_TO_STDERR redirects Test::Builder::output to
   STDERR so cassandane can see it, for example.