### PR TITLE
Be less strict about cyradm output

### DIFF
--- a/lib/JMAP/TestSuite/ServerAdapter/Cyrus.pm
+++ b/lib/JMAP/TestSuite/ServerAdapter/Cyrus.pm
@@ -119,7 +119,7 @@ sub pristine_account {
              | $cyradm --notls -u $cyr_user -w $cyr_pass $host $port";
 
   my $res = `$cmd 2>&1`;
-  unless ($res =~ /^\s*[^\s]+>\s*[^\s]+>\s*$/) {
+  unless ($res =~ /\s*[^\s]+>\s*[^\s]+>\s*$/) {
     die "Failed to run $cmd: $res\n";
   }
 


### PR DESCRIPTION
pristine_test would fail if TERM was unset, for example,
because the output would contain warnings