### PR TITLE
jmap-session-resource: expect eventSourceUrl

### DIFF
--- a/t/core/jmap-session-resource.t
+++ b/t/core/jmap-session-resource.t
@@ -44,7 +44,7 @@ test {
       downloadUrl => jstr,
       uploadUrl => jstr,
       state => jstr,
-#      eventSourceUrl => jstr, # XXX - Spec updates might change
+      eventSourceUrl => jstr,
     },
     'Response looks good',
   ) or diag explain $data;


### PR DESCRIPTION
Cyrus includes eventSourceUrl as of https://github.com/cyrusimap/cyrus-imapd/commit/f81be7f706, which means it now fails this test.  This seems to fix it.