### PR TITLE
email entity: remove obsolete properties

### DIFF
--- a/lib/JMAP/TestSuite/Entity/Email.pm
+++ b/lib/JMAP/TestSuite/Entity/Email.pm
@@ -27,10 +27,6 @@ with 'JMAP::TestSuite::Entity' => {
     htmlBody
     attachments
     attachedEmails
-    isUnread
-    isFlagged
-    isAnswered
-    isDraft
   ) ],
 
   # I'm not sure the is* flags are still valid XXX
@@ -126,9 +122,6 @@ sub import_messages {
   # uploading
   my %upload_failure;
   for my $crid (keys %$to_import) {
-    $to_import->{$crid}{$_} //= \0
-      for qw(isUnread isAnswered isFlagged isDraft);
-
     my $blob = $to_import->{$crid}{blobId};
     next unless blessed $blob;
 


### PR DESCRIPTION
is*-style keywords are from a pre-RFC version of JMAP, and have been entirely replaced by the keywords property. Support for this was added in 92b6665a (Port JMAP::TestSuite to the new JMAP spec, 2018-02-20), but the old properties remained.