### PR TITLE
Check for oldstate, newState in Email/import response

### DIFF
--- a/t/Email/import/good-imports.t
+++ b/t/Email/import/good-imports.t
@@ -30,6 +30,8 @@ test {
       $res->single_sentence('Email/import')->arguments,
       {
         accountId  => jstr($account->accountId),
+        oldState => jstr(),
+        newState => jstr(),
         notCreated => {},
         created => {
           new => {
@@ -113,6 +115,8 @@ test {
       $res->single_sentence('Email/import')->arguments,
       {
         accountId  => jstr($account->accountId),
+        oldState => jstr(),
+        newState => jstr(),
         notCreated => {},
         created => {
           new => {
@@ -199,6 +203,8 @@ test {
       $res->single_sentence('Email/import')->arguments,
       {
         accountId  => jstr($account->accountId),
+        oldState => jstr(),
+        newState => jstr(),
         notCreated => {},
         created => {
           new => {

--- a/t/Email/import/one-fails-another-succeeds.t
+++ b/t/Email/import/one-fails-another-succeeds.t
@@ -34,6 +34,8 @@ test {
     $res->single_sentence('Email/import')->arguments,
     {
       accountId  => jstr($account->accountId),
+      oldState => jstr(),
+      newState => jstr(),
       notCreated => {
         new2 => {
           type => 'invalidProperties',


### PR DESCRIPTION
Cyrus PR https://github.com/cyrusimap/cyrus-imapd/pull/4457 will return oldState and newState.

I don't know if there is a way to support responses both with/without these arguments