### PR TITLE
session resource: add a requirement for "mail" capability

### DIFF
--- a/t/core/jmap-session-resource.t
+++ b/t/core/jmap-session-resource.t
@@ -23,9 +23,21 @@ test {
           name => jstr,
           isPrimary => jbool,
           isReadOnly => jbool,
+          accountCapabilities => superhashof({
+            'urn:ietf:params:jmap:core' => {},
+            'urn:ietf:params:jmap:mail' => {
+              maxMailboxesPerEmail => any(jnum, undef),
+              maxMailboxDepth => any(jnum, undef),
+              maxSizeMailboxName => jnum,
+              maxSizeAttachmentsPerEmail => jnum,
+              emailQuerySortOptions => superbagof(),
+              mayCreateTopLevelMailbox => jbool,
+            },
+          }),
         }),
       },
       capabilities => superhashof({
+        'urn:ietf:params:jmap:mail' => {},
         'urn:ietf:params:jmap:core' => {
           maxSizeUpload => jnum,
           maxConcurrentUpload => jnum,


### PR DESCRIPTION
The whole JMAP TestSuite assumes mail is available right now.  This will require its capabilities are all defined.  They could still be better defined, as jnum() will permit -1, which UnsignedInt in the spec will not.