### PR TITLE
Jmap proxy tests

### DIFF
--- a/eg/proxy.json
+++ b/eg/proxy.json
@@ -1,5 +1,13 @@
 {
-  "adapter"   : "JMAPProxy",
-  "accountIds": [ "b0b7699c-4474-11e6-b790-f23c91556942" ],
-  "base_uri"  : "http://localhost:9000/"
+  "adapter"                    : "JMAPProxy",
+  "accountIds"                 : [ "user1" ],
+  "base_uri"                   : "http://localhost:9000/",
+  "mgmt_uri"                   : "http://localhost:8081/",
+  "cyrus_host"                 : "localhost",
+  "cyrus_port"                 : 8143,
+  "cyrus_http_url"             : "http://localhost:8080",
+  "cyrus_password"             : "password",
+  "cyrus_admin_user"           : "admin",
+  "cyrus_admin_pass"           : "admin",
+  "cyrus_hierarchy_separator"  : "."
 }

--- a/lib/JMAP/TestSuite/ServerAdapter/JMAPProxy.pm
+++ b/lib/JMAP/TestSuite/ServerAdapter/JMAPProxy.pm
@@ -2,7 +2,20 @@ package JMAP::TestSuite::ServerAdapter::JMAPProxy;
 use Moose;
 with 'JMAP::TestSuite::ServerAdapter';
 
+use Data::GUID qw(guid_string);
+use LWP::UserAgent;
+use Mail::IMAPClient;
+use JSON qw(encode_json decode_json);
+
+our $STARTTIME = time();
+our $USERNUM = 1;
+
 has base_uri => (
+  is => 'ro',
+  required => 1,
+);
+
+has mgmt_uri => (
   is => 'ro',
   required => 1,
 );
@@ -14,21 +27,120 @@ has accountIds => (
   required => 1,
 );
 
-sub any_account {
-  my ($self) = @_;
+has cyrus_host => (
+  is => 'ro',
+  default => 'localhost',
+);
 
+has cyrus_port => (
+  is => 'ro',
+);
+
+has cyrus_admin_user => (
+  is => 'ro',
+  default => 'admin',
+);
+
+has cyrus_admin_pass => (
+  is => 'ro',
+  default => 'secret',
+);
+
+has cyrus_admin_use_ssl => (
+  is => 'ro',
+  default => 0,
+);
+
+has cyrus_hierarchy_separator => (
+  is => 'ro',
+  default => '/',
+);
+
+# JMAPProxy-specific: password for IMAP user accounts (not admin)
+has cyrus_password => (
+  is => 'ro',
+  default => 'password',
+);
+
+# JMAPProxy-specific: CalDAV/CardDAV URL for proxy config
+has cyrus_http_url => (
+  is => 'ro',
+  default => 'http://localhost:8080',
+);
+
+has imap_client => (
+  is  => 'ro',
+  isa => 'Mail::IMAPClient',
+  lazy => 1,
+  default => sub {
+    my ($self) = @_;
+
+    Mail::IMAPClient->new(
+      Server   => $self->cyrus_host,
+      Port     => $self->cyrus_port,
+      Ssl      => $self->cyrus_admin_use_ssl ? 1 : 0,
+
+      User     => $self->cyrus_admin_user,
+      Password => $self->cyrus_admin_pass,
+      Uid      => 1,
+    ) or die "Failed to connect to cyrus imap: $@\n";
+  },
+);
+
+sub _make_account {
+  my ($self, $accountId) = @_;
   my $base = $self->base_uri =~ s{/\z}{}r;
-
-  my ($accountId) = $self->accountIds;
-
   return JMAP::TestSuite::Account::JMAPProxy->new({
     server    => $self,
     accountId => $accountId,
-
     api_uri       => "$base/jmap/$accountId",
-    download_uri  => "$base/raw/$accountId",
+    download_uri  => "$base/raw/{accountId}/{blobId}/{name}",
     upload_uri    => "$base/upload/$accountId",
   });
+}
+
+sub any_account {
+  my ($self) = @_;
+  my ($accountId) = $self->accountIds;
+  return $self->_make_account($accountId);
+}
+
+sub pristine_account {
+  my ($self) = @_;
+
+  my $num = $USERNUM++;
+  my $user = "jt-$STARTTIME-$$-$num";
+
+  my $sep = $self->cyrus_hierarchy_separator;
+  my $folder = "user$sep$user";
+
+  # 1. Create Cyrus user via IMAP admin
+  my $client = $self->imap_client;
+  die "Failed to create user" unless $client->create($folder);
+  die "Failed to setacl" unless $client->setacl($folder, $user, "lrswipkxtecdan");
+
+  # 2. Tell the proxy about the new account via management API
+  my $mgmt = $self->mgmt_uri =~ s{/\z}{}r;
+  my $content = encode_json({
+    accountid  => $user,
+    type       => 'imap',
+    username   => $user,
+    password   => $self->cyrus_password,
+    imapHost   => $self->cyrus_host,
+    imapPort   => $self->cyrus_port,
+    imapSSL    => 1,
+    caldavURL  => $self->cyrus_http_url,
+    carddavURL => $self->cyrus_http_url,
+  });
+  my $lwp = LWP::UserAgent->new();
+  my $res = $lwp->post("$mgmt/api/accounts",
+   Content_Type => 'application/json',
+   Content => $content
+  );
+  die "Failed to create proxy account for $user: " . $res->status_line . "\n"
+    unless $res->is_success;
+
+  return $self->_make_account($user);
 }
 
 package JMAP::TestSuite::Account::JMAPProxy {
@@ -43,8 +155,9 @@ package JMAP::TestSuite::Account::JMAPProxy {
 
   sub authenticated_tester {
     my $tester = JMAP::TestSuite::JMAP::Tester::WithSugar->new({
-      api_uri     => $_[0]->api_uri,
-      upload_uri  => $_[0]->upload_uri,
+      api_uri      => $_[0]->api_uri,
+      upload_uri   => $_[0]->upload_uri,
+      download_uri => $_[0]->download_uri,
     });
 
     $tester->ua->lwp->ssl_opts(verify_hostname => 0);

--- a/t/Email/queryChanges/simple.t
+++ b/t/Email/queryChanges/simple.t
@@ -116,7 +116,7 @@ test {
         oldQueryState => $query_state,
         newQueryState => none($query_state),
         added         => [ ],
-        removed       => [ ],
+        removed       => ignore, # server MAY include extra IDs (RFC 8620 §5.6)
       }),
       "expected resposne",
     );
@@ -186,7 +186,7 @@ test {
         oldQueryState => $query_state,
         newQueryState => none($query_state),
         added         => [ ],
-        removed       => [ ],
+        removed       => ignore, # server MAY include extra IDs (RFC 8620 §5.6)
       }),
       "expected resposne",
     );

--- a/t/Email/queryChanges/simple.t
+++ b/t/Email/queryChanges/simple.t
@@ -29,7 +29,9 @@ test {
   );
 
   # Ugh, squatter needs time to index things
-  sleep 1 if $self->server->isa('JMAP::TestSuite::ServerAdapter::Cyrus');
+  # Squatter needs time to index for full-text search
+  sleep 1 if $self->server->isa('JMAP::TestSuite::ServerAdapter::Cyrus')
+          || $self->server->isa('JMAP::TestSuite::ServerAdapter::JMAPProxy');
 
   # Get our baseline
   my ($baseline_res) = $self->test_query(
@@ -68,7 +70,9 @@ test {
   my $match2 = $mailbox->add_message({ subject => 'aaa 2' });
 
   # Ugh, squatter needs time to index things
-  sleep 1 if $self->server->isa('JMAP::TestSuite::ServerAdapter::Cyrus');
+  # Squatter needs time to index for full-text search
+  sleep 1 if $self->server->isa('JMAP::TestSuite::ServerAdapter::Cyrus')
+          || $self->server->isa('JMAP::TestSuite::ServerAdapter::JMAPProxy');
 
   subtest "added message that matches" => sub {
     my ($res) = $tester->request_ok(
@@ -95,7 +99,9 @@ test {
   my $no_match2 = $mailbox->add_message({ subject => 'bbb 2' });
 
   # Ugh, squatter needs time to index things
-  sleep 1 if $self->server->isa('JMAP::TestSuite::ServerAdapter::Cyrus');
+  # Squatter needs time to index for full-text search
+  sleep 1 if $self->server->isa('JMAP::TestSuite::ServerAdapter::Cyrus')
+          || $self->server->isa('JMAP::TestSuite::ServerAdapter::JMAPProxy');
 
   subtest "added message that doesn't match" => sub {
     my ($res) = $tester->request_ok(

--- a/t/Email/set/create/attachments-using-blob-id.t
+++ b/t/Email/set/create/attachments-using-blob-id.t
@@ -97,7 +97,7 @@ test {
               disposition => 'attachment',
               name        => 'image.jpg',
               cid         => 'fooz',
-              blobId      => $blob->blobId,
+              blobId      => jstr(), # server may assign a new blobId
             },
           ],
           bcc         => undef,
@@ -150,4 +150,17 @@ test {
       value             => 'this is a text part',
     },
   );
+
+  # If server assigned a new blobId, verify content is unchanged
+  my $att = $email->{attachments}[0];
+  my $orig_blob_id = $blob->blobId;
+  if ($att && $att->{blobId} && $att->{blobId} ne $orig_blob_id) {
+    my $download = $tester->download({
+      blobId    => $att->{blobId},
+      accountId => $account->accountId,
+      name      => 'image.jpg',
+    });
+    ok($download->is_success, 'downloaded attachment blob');
+    is(${ $download->bytes_ref }, 'image data', 'attachment content preserved despite new blobId');
+  }
 };

--- a/t/Email/set/create/html-body-using-blob-id.t
+++ b/t/Email/set/create/html-body-using-blob-id.t
@@ -55,7 +55,7 @@ test {
   ok($id, 'got the id');
 
   my %body = (
-    blobId      => $blob->blobId,
+    blobId      => jstr(), # server may assign a new blobId
     charset     => 'us-ascii',
     cid         => 'fooz',
     disposition => undef,

--- a/t/Email/set/create/text-body-using-blob-id.t
+++ b/t/Email/set/create/text-body-using-blob-id.t
@@ -57,7 +57,7 @@ test {
   ok($id, 'got the id');
 
   my %body = (
-    blobId      => $blob->blobId,
+    blobId      => jstr(), # server may assign a new blobId
     charset     => 'us-ascii',
     cid         => 'fooz',
     disposition => undef,
@@ -129,5 +129,6 @@ test {
       isTruncated       => jfalse(),
       value             => 'Hello there',
     },
+    'body value content matches original blob',
   );
 };

--- a/t/Mailbox/get/no-existing-entities.t
+++ b/t/Mailbox/get/no-existing-entities.t
@@ -6,10 +6,7 @@ attr pristine => 1;
 test {
   my ($self) = @_;
 
-  plan skip_all => "Cyrus requires at least one mailbox"
-    if $self->server->isa('JMAP::TestSuite::ServerAdapter::Cyrus');
-
-  my $account = $self->any_account;
+  my $account = $self->pristine_account;
   my $tester  = $account->tester;
 
   subtest "No arguments" => sub {
@@ -19,15 +16,20 @@ test {
     ok($res->is_success, "Mailbox/get")
       or diag explain $res->response_payload;
 
+    my $args = $res->single_sentence("Mailbox/get")->arguments;
+
     jcmp_deeply(
-      $res->single_sentence("Mailbox/get")->arguments,
+      $args,
       superhashof({
         accountId => jstr($account->accountId),
         state     => jstr(),
-        list      => [],
         notFound  => [],
       }),
-      "No mailboxes looks good",
+      "Mailbox/get response looks good",
     );
+
+    # Filter out INBOX — most servers auto-create it
+    my @non_inbox = grep { ($_->{role} // '') ne 'inbox' } @{ $args->{list} };
+    is(scalar @non_inbox, 0, "No non-INBOX mailboxes exist");
   };
 };

--- a/t/Mailbox/get/no-existing-entities.t
+++ b/t/Mailbox/get/no-existing-entities.t
@@ -30,6 +30,6 @@ test {
 
     # Filter out INBOX — most servers auto-create it
     my @non_inbox = grep { ($_->{role} // '') ne 'inbox' } @{ $args->{list} };
-    is(scalar @non_inbox, 0, "No non-INBOX mailboxes exist");
+    is(@non_inbox, 0, "No non-INBOX mailboxes exist");
   };
 };

--- a/t/Mailbox/query/no-existing-entities.t
+++ b/t/Mailbox/query/no-existing-entities.t
@@ -38,7 +38,7 @@ test {
       ]]);
       my @non_inbox = grep { ($_->{role} // '') ne 'inbox' }
         @{ $get_res->single_sentence("Mailbox/get")->arguments->{list} };
-      is(scalar @non_inbox, 0, "No non-INBOX mailboxes exist");
+      is(@non_inbox, 0, "No non-INBOX mailboxes exist");
     } else {
       pass("No mailboxes at all");
     }

--- a/t/Mailbox/query/no-existing-entities.t
+++ b/t/Mailbox/query/no-existing-entities.t
@@ -7,9 +7,6 @@ attr pristine => 1;
 test {
   my ($self) = @_;
 
-  plan skip_all => "Cyrus requires at least one mailbox"
-    if $self->server->isa('JMAP::TestSuite::ServerAdapter::Cyrus');
-
   my $account = $self->pristine_account;
   my $tester  = $account->tester;
 
@@ -20,17 +17,30 @@ test {
     ok($res->is_success, "Mailbox/query")
       or diag explain $res->response_payload;
 
+    my $args = $res->single_sentence("Mailbox/query")->arguments;
+
     jcmp_deeply(
-      $res->single_sentence("Mailbox/query")->arguments,
+      $args,
       superhashof({
         accountId  => jstr($account->accountId),
         queryState => jstr(),
         position   => jnum(0),
-        total      => jnum(0),
-        ids        => [],
         canCalculateChanges => jbool(),
       }),
-      "No mailboxes looks good",
+      "Mailbox/query response looks good",
     ) or diag explain $res->as_stripped_triples;
+
+    # Filter out INBOX from results — most servers auto-create it
+    my @ids = @{ $args->{ids} };
+    if (@ids) {
+      my $get_res = $tester->request([[
+        "Mailbox/get" => { ids => \@ids },
+      ]]);
+      my @non_inbox = grep { ($_->{role} // '') ne 'inbox' }
+        @{ $get_res->single_sentence("Mailbox/get")->arguments->{list} };
+      is(scalar @non_inbox, 0, "No non-INBOX mailboxes exist");
+    } else {
+      pass("No mailboxes at all");
+    }
   };
 };

--- a/t/Mailbox/set/create/immutable-fields.t
+++ b/t/Mailbox/set/create/immutable-fields.t
@@ -87,7 +87,7 @@ test {
     $mb->{myRights} = \%rights;
     $mb->{$_} = 52 for qw(
       totalEmails
-      unrealEmails
+      unreadEmails
       totalThreads
       unreadThreads
     );


### PR DESCRIPTION
This PR updates the JMAPProxy test adaptor and example config, as well as fixing a few tests where the test was either hitting Cyrus backend issues (sleep for squatter) or assuming things which the JMAP spec doesn't guarantee (spurious deletes, blobId changes, accounts with no role=inbox auto created)

This allows a couple more tests to run against Cyrus too (since it likewise always creates an INBOX)